### PR TITLE
Upgrade the versions of the stream libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This library provides a way to integrate scalikejdbc to various stream libraries.
 Stream libraries are useful to handle huge result set.
 
-Currently it supports scalikejdbc 2.4.1, akka-stream 2.4.x, fs2 0.9.0-M6, scalaz-stream 0.8.2.
+Currently it supports scalikejdbc 3.3.2, akka-stream 2.5.x, fs2 1.0.5, scalaz-stream 0.8.6.
 
 ## scalikejdbc-stream-akka
 

--- a/akka/src/main/scala/scalikejdbc/stream/akka/SQLSource.scala
+++ b/akka/src/main/scala/scalikejdbc/stream/akka/SQLSource.scala
@@ -12,12 +12,10 @@ object SQLSource {
   def apply[A, E <: WithExtractor](sql: SQL[A, E], pool: ConnectionPool)(
     implicit
     hasExtractor: sql.ThisSQL =:= sql.SQLWithExtractor,
-    ec: ExecutionContext
-  ): Source[A, NotUsed] = {
+    ec: ExecutionContext): Source[A, NotUsed] = {
     Source.unfoldResourceAsync[A, ResultSetIterator[A]](
       () => Future(SQLToRsIterator.toResultSetIterator(sql, pool)),
       it => Future(if (it.hasNext) Some(it.next()) else None),
-      it => Future { it.onFinish(); Done }
-    )
+      it => Future { it.onFinish(); Done })
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 val _versions = new {
-  val scalikejdbc = "2.4.1"
+  val scalikejdbc = "3.3.2"
 }
 
 val commonSettings = Seq(
@@ -10,7 +10,7 @@ val commonSettings = Seq(
     "scm:git:github.com:tkawachi/scalikejdbc-akka-stream-test.git"
   )),
 
-  scalaVersion := "2.11.8",
+  scalaVersion := "2.12.8",
   scalacOptions ++= Seq(
     "-deprecation",
     "-encoding", "UTF-8",
@@ -21,9 +21,9 @@ val commonSettings = Seq(
   ),
 
   libraryDependencies ++= Seq(
-    "ch.qos.logback" % "logback-classic" % "1.1.7" % "test",
-    "com.h2database" % "h2" % "1.4.191" % "test",
-    "org.scalatest" %% "scalatest" % "2.2.6" % "test",
+    "ch.qos.logback" % "logback-classic" % "1.2.3" % "test",
+    "com.h2database" % "h2" % "1.4.197" % "test",
+    "org.scalatest" %% "scalatest" % "3.0.5" % "test",
     "org.scalikejdbc" %% "scalikejdbc" % _versions.scalikejdbc % "test"
   )
 )
@@ -52,7 +52,7 @@ lazy val fs2 = project.in(file("fs2"))
     name := "scalikejdbc-stream-fs2",
     description := "Scalikejdbc stream FS2",
     libraryDependencies ++= Seq(
-      "co.fs2" %% "fs2-core" % "0.9.0-M6"
+      "co.fs2" %% "fs2-core" % "1.0.5"
     )
   )
   .dependsOn(stream)
@@ -63,7 +63,7 @@ lazy val akka = project.in(file("akka"))
     name := "scalikejdbc-stream-akka",
     description := "Scalikejdbc stream Akka",
     libraryDependencies ++= Seq(
-      "com.typesafe.akka" %% "akka-stream" % "2.4.8"
+      "com.typesafe.akka" %% "akka-stream" % "2.5.23"
     )
   )
   .dependsOn(stream)
@@ -74,7 +74,7 @@ lazy val scalaz = project.in(file("scalaz"))
     name := "scalikejdbc-stream-scalaz",
     description := "Scalikejdbc stream Akka",
     libraryDependencies ++= Seq(
-      "org.scalaz.stream" %% "scalaz-stream" % "0.8.2"
+      "org.scalaz.stream" %% "scalaz-stream" % "0.8.6"
     )
   )
   .dependsOn(stream)

--- a/fs2/src/main/scala/scalikejdbc/stream/fs2/SQLStream.scala
+++ b/fs2/src/main/scala/scalikejdbc/stream/fs2/SQLStream.scala
@@ -1,7 +1,11 @@
 package scalikejdbc.stream.fs2
 
 import _root_.fs2._
+import cats.effect.ContextShift
+import cats.effect.IO
+import cats.syntax.apply._
 import scalikejdbc.GeneralizedTypeConstraintsForWithExtractor.=:=
+import scalikejdbc.stream.ResultSetIterator
 import scalikejdbc.stream.SQLToRsIterator
 import scalikejdbc.{ ConnectionPool, SQL, WithExtractor }
 
@@ -10,10 +14,11 @@ object SQLStream {
   def apply[A, E <: WithExtractor](sql: SQL[A, E], pool: ConnectionPool)(
     implicit
     hasExtractor: sql.ThisSQL =:= sql.SQLWithExtractor,
-    S: Strategy): Stream[Task, A] = {
-    Stream.bracket(Task(SQLToRsIterator.toResultSetIterator(sql, pool)))(
-      s => Stream.unfoldEval(s)(s => Task(if (s.hasNext) Some((s.next(), s)) else None)),
-      s => Task(s.onFinish()))
+    cs: ContextShift[IO]): Stream[IO, A] = {
+    def acquire = IO.shift *> IO(SQLToRsIterator.toResultSetIterator(sql, pool))
+    def release(s: ResultSetIterator[A]) = IO.shift *> IO(s.onFinish())
+    Stream.bracket(acquire)(release)
+      .flatMap(s => Stream.unfoldEval(s)(s => IO.shift *> IO(if (s.hasNext) Some((s.next(), s)) else None)))
   }
 
 }

--- a/fs2/src/main/scala/scalikejdbc/stream/fs2/SQLStream.scala
+++ b/fs2/src/main/scala/scalikejdbc/stream/fs2/SQLStream.scala
@@ -10,12 +10,10 @@ object SQLStream {
   def apply[A, E <: WithExtractor](sql: SQL[A, E], pool: ConnectionPool)(
     implicit
     hasExtractor: sql.ThisSQL =:= sql.SQLWithExtractor,
-    S: Strategy
-  ): Stream[Task, A] = {
+    S: Strategy): Stream[Task, A] = {
     Stream.bracket(Task(SQLToRsIterator.toResultSetIterator(sql, pool)))(
       s => Stream.unfoldEval(s)(s => Task(if (s.hasNext) Some((s.next(), s)) else None)),
-      s => Task(s.onFinish())
-    )
+      s => Task(s.onFinish()))
   }
 
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.5")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")

--- a/scalaz/src/main/scala/scalikejdbc/stream/scalaz/SQLStream.scala
+++ b/scalaz/src/main/scala/scalikejdbc/stream/scalaz/SQLStream.scala
@@ -15,8 +15,7 @@ object SQLStream {
   def apply[A, E <: WithExtractor](sql: SQL[A, E], pool: ConnectionPool)(
     implicit
     hasExtractor: sql.ThisSQL =:= sql.SQLWithExtractor,
-    es: ExecutorService
-  ): Process[Task, A] = {
+    es: ExecutorService): Process[Task, A] = {
     iteratorR(Task(SQLToRsIterator.toResultSetIterator(sql, pool)))(s => Task(s.onFinish()))(s => Task(s))
   }
 }

--- a/stream/src/main/scala/scalikejdbc/stream/ResultSetIterator.scala
+++ b/stream/src/main/scala/scalikejdbc/stream/ResultSetIterator.scala
@@ -5,11 +5,10 @@ import java.sql.ResultSet
 import scalikejdbc.{ ResultSetCursor, WrappedResultSet }
 
 class ResultSetIterator[+A] private (
-    rs: ResultSet,
-    extractor: WrappedResultSet => A,
-    val onFinish: () => Unit,
-    cursor: ResultSetCursor
-) extends Iterator[A] {
+  rs: ResultSet,
+  extractor: WrappedResultSet => A,
+  val onFinish: () => Unit,
+  cursor: ResultSetCursor) extends Iterator[A] {
 
   def this(rs: ResultSet, extractor: WrappedResultSet => A, onFinish: () => Unit) =
     this(rs, extractor, onFinish, new ResultSetCursor(0))

--- a/stream/src/main/scala/scalikejdbc/stream/SQLToRsIterator.scala
+++ b/stream/src/main/scala/scalikejdbc/stream/SQLToRsIterator.scala
@@ -4,7 +4,7 @@ import scalikejdbc.GeneralizedTypeConstraintsForWithExtractor.=:=
 import scalikejdbc.{ ConnectionPool, DBConnectionAttributesWiredResultSet, DBSession, LogSupport, SQL, SQLToResult, WithExtractor, WrappedResultSet }
 
 private[stream] trait SQLToRsIterator[A, E <: WithExtractor]
-    extends SQLToResult[A, E, ResultSetIterator] {
+  extends SQLToResult[A, E, ResultSetIterator] {
 
   def result[AA](f: WrappedResultSet => AA, session: DBSession): ResultSetIterator[AA] = {
     val executor = session.toStatementExecutor(statement, rawParameters)
@@ -32,8 +32,7 @@ private[stream] object SQLToRsIterator extends LogSupport {
 
   def toResultSetIterator[A, E <: WithExtractor](sql: SQL[A, E], pool: ConnectionPool)(
     implicit
-    hasExtractor: sql.ThisSQL =:= sql.SQLWithExtractor
-  ): ResultSetIterator[A] = {
+    hasExtractor: sql.ThisSQL =:= sql.SQLWithExtractor): ResultSetIterator[A] = {
     implicit val session = DBSession(pool.borrow(), isReadOnly = true)
     val iterator = SQLToRsIterator(sql).apply()
     iterator.appendOnFinish(() => session.close())

--- a/stream/src/main/scala/scalikejdbc/stream/SQLToRsIterator.scala
+++ b/stream/src/main/scala/scalikejdbc/stream/SQLToRsIterator.scala
@@ -10,16 +10,7 @@ private[stream] trait SQLToRsIterator[A, E <: WithExtractor]
     val executor = session.toStatementExecutor(statement, rawParameters)
     val proxy = new DBConnectionAttributesWiredResultSet(executor.executeQuery(), session.connectionAttributes)
 
-    new ResultSetIterator(proxy, f, () => {
-      try {
-        executor.close()
-      } finally {
-        // see DBSession#using()
-        session.fetchSize(None)
-        // session.tags() // TODO clear tags to Vector.empty
-        session.queryTimeout(None)
-      }
-    })
+    new ResultSetIterator(proxy, f, () => executor.close())
   }
 }
 

--- a/stream/src/main/scala/scalikejdbc/stream/SQLToRsIteratorImpl.scala
+++ b/stream/src/main/scala/scalikejdbc/stream/SQLToRsIteratorImpl.scala
@@ -3,12 +3,10 @@ package scalikejdbc.stream
 import scalikejdbc.{ HasExtractor, SQL, WithExtractor, WrappedResultSet }
 
 private[stream] class SQLToRsIteratorImpl[A, E <: WithExtractor](
-  override val statement: String, private[scalikejdbc] override val rawParameters: Seq[Any]
-)(
-  override val extractor: WrappedResultSet => A
-)
-    extends SQL[A, E](statement, rawParameters)(extractor)
-    with SQLToRsIterator[A, E] {
+  override val statement: String, private[scalikejdbc] override val rawParameters: Seq[Any])(
+  override val extractor: WrappedResultSet => A)
+  extends SQL[A, E](statement, rawParameters)(extractor)
+  with SQLToRsIterator[A, E] {
 
   override protected def withParameters(params: Seq[Any]): SQLToRsIterator[A, E] = {
     new SQLToRsIteratorImpl[A, E](statement, params)(extractor)


### PR DESCRIPTION
Nice to meet you!

This PR upgrades Scala and the streaming libraries to the (semi-)latest versions. Notably, it now targets:

- Scala-2.12.8
- ScalikeJDBC-3.3.2
- fs2-core-1.0.5

`ResultSetIterator` and `fs2.SQLStream` were modified to fix a runtime error and a compile-time error, respectively.